### PR TITLE
Add input should-create-pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ binaries/libraries in a downstream project.
     circt-config: ''
 
     # An optional script to decide whether to open the Pull Request or not.
-    # If there is a new version of CIRCT, the action will run the provided
-    # script. A return value of 0 means "open the PR". A return value of 1
-    # means "do not open the PR". Any other return value will cause the action
-    # to exit with an error.
+    # The script must accept a single positional argument (the new CIRCT
+    # version). The script is only run when there is a new version of CIRCT.  A
+    # return value of 0 means "open the PR". A return value of 1 means "do not
+    # open the PR". Any other return value will cause the action to exit with
+    # an error. Note, the default value 'true' is the shell built-in, not a
+    # boolean value.
     #
-    # Default: ''
+    # Default: 'true'
     should-create-pr: ''
 
     # A GitHub token with sufficient permissions to create Pull Requests

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ binaries/libraries in a downstream project.
     # Default: './etc/circt.json'
     circt-config: ''
 
+    # An optional script to decide whether to open the Pull Request or not.
+    # If there is a new version of CIRCT, the action will run the provided
+    # script. A return value of 0 means "open the PR". A return value of 1
+    # means "do not open the PR". Any other return value will cause the action
+    # to exit with an error.
+    #
+    # Default: ''
+    should-create-pr: ''
+
     # A GitHub token with sufficient permissions to create Pull Requests
     #
     # Default: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,15 @@ inputs:
       that this is a JSON object containing a key "version".
     type: string
     default: './etc/circt.json'
+  should-create-pr:
+    description: |
+      An optional script to decide whether to open the Pull Request or not.
+      If there is a new version of CIRCT, the action will run the provided
+      script. A return value of 0 means "open the PR". A return value of 1
+      means "do not open the PR". Any other return value will cause the action
+      to exit with an error.
+    type: string
+    default: ''
   github-token:
     description: |
       A GitHub token with sufficient permissions to create Pull Requests
@@ -86,6 +95,33 @@ runs:
         VERSION=$(git tag --list 'firtool-*' | tail -n1)
         echo version=$VERSION >> $GITHUB_OUTPUT
         echo Latest version is: \`$VERSION\` >> $GITHUB_STEP_SUMMARY
+    - name: Decide whether or not to open PR
+      id: open-pr
+      shell: bash
+      run: |
+        VERSION=${{ steps.get-version-latest.outputs.version }}
+        if [[ ${{ steps.get-version-current.outputs.version }} != "$VERSION" ]]; then
+          if [[ -n "${{ inputs.should-create-pr }}" ]]; then
+            if $(downstream/${{ inputs.should-create-pr }} "$VERSION"); then
+              RESULT="0"
+            else
+              RESULT=$?
+            fi
+          else
+            RESULT="0"
+          fi
+          if [[ "$RESULT" -eq "0" ]]; then
+            echo "result=yes" >> $GITHUB_OUTPUT
+          elif [[ "$RESULT" -eq "1" ]]; then
+            echo "::notice::User provided ${{ inputs.should-create-pr }} returned 1, skipping PR creation..."
+            echo "result=no" >> $GITHUB_OUTPUT
+          else
+            echo "::error::User provided ${{ inputs.should-create-pr }} returned $RESULT, aborting..."
+            exit 1
+          fi
+        else
+          echo "result=no" >> $GITHUB_OUTPUT
+        fi
 
     ############################################################################
     # The rest of this action handles bumping the CIRCT version if a new version
@@ -106,7 +142,7 @@ runs:
     # [2]: "base" is GitHub lingo for "the branch without your changes".
     ############################################################################
     - name: Create PR Metadata
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       shell: bash
       # Write a JSON object to the temporary file `metadata/metadata.json` that
       # contains information about what this job is going to do.  Populate four
@@ -223,7 +259,7 @@ runs:
     #
     # [3]: https://pandoc.org/
     - name: Generate PR Title
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       uses: docker://pandoc/core
       with:
         args: >-
@@ -234,7 +270,7 @@ runs:
           -o metadata/pr-title.md
           /dev/null
     - name: Generate PR Body
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       uses: docker://pandoc/core
       with:
         args: >-
@@ -245,7 +281,7 @@ runs:
           -o metadata/pr-body.md
           /dev/null
     - name: Generate Commit Message
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       uses: docker://pandoc/core
       with:
         args: >-
@@ -258,7 +294,7 @@ runs:
     # Print the populated pandoc templates to the GitHub Actions step summary.
     # (These will print on the "Summary" of a run of this Action.)
     - name: Show Metadata
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       shell: bash
       run: |
         echo "# PR Title" >> $GITHUB_STEP_SUMMARY
@@ -272,7 +308,7 @@ runs:
     # Using the information in the JSON Metadata, cherry-pick all commits from
     # the staging branch.
     - name: Cherry Pick Staging Branch Commits
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       shell: bash
       run: |
         cd downstream/
@@ -287,7 +323,7 @@ runs:
         done
     # Create unstaged changes that updates the CIRCT version to "latest".
     - name: Update Downstream Project to Latest Upstream Release
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       shell: bash
       run: |
         cd downstream/
@@ -306,7 +342,7 @@ runs:
       #
       # [4]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
     - name: Setup Environment with Metadata
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       id: setup-env
       shell: bash
       run: |
@@ -322,7 +358,7 @@ runs:
     # Commit unstaged changes, create or update the PR, notify reviewers, and
     # add labels.
     - name: Create PR
-      if: steps.get-version-current.outputs.version != steps.get-version-latest.outputs.version
+      if: steps.open-pr.outputs.result == 'yes'
       id: create-pr
       uses: peter-evans/create-pull-request@v5
       with:

--- a/action.yml
+++ b/action.yml
@@ -41,12 +41,14 @@ inputs:
   should-create-pr:
     description: |
       An optional script to decide whether to open the Pull Request or not.
-      If there is a new version of CIRCT, the action will run the provided
-      script. A return value of 0 means "open the PR". A return value of 1
-      means "do not open the PR". Any other return value will cause the action
-      to exit with an error.
+      The script must accept a single positional argument (the new CIRCT
+      version). The script is only run when there is a new version of CIRCT.  A
+      return value of 0 means "open the PR". A return value of 1 means "do not
+      open the PR". Any other return value will cause the action to exit with
+      an error. Note, the default value 'true' is the shell built-in, not a
+      boolean value.
     type: string
-    default: ''
+    default: 'true'
   github-token:
     description: |
       A GitHub token with sufficient permissions to create Pull Requests
@@ -99,28 +101,28 @@ runs:
       id: open-pr
       shell: bash
       run: |
+        cd downstream
         VERSION=${{ steps.get-version-latest.outputs.version }}
-        if [[ ${{ steps.get-version-current.outputs.version }} != "$VERSION" ]]; then
-          if [[ -n "${{ inputs.should-create-pr }}" ]]; then
-            if $(downstream/${{ inputs.should-create-pr }} "$VERSION"); then
-              RESULT="0"
-            else
-              RESULT=$?
-            fi
-          else
-            RESULT="0"
-          fi
-          if [[ "$RESULT" -eq "0" ]]; then
-            echo "result=yes" >> $GITHUB_OUTPUT
-          elif [[ "$RESULT" -eq "1" ]]; then
-            echo "::notice::User provided ${{ inputs.should-create-pr }} returned 1, skipping PR creation..."
-            echo "result=no" >> $GITHUB_OUTPUT
-          else
-            echo "::error::User provided ${{ inputs.should-create-pr }} returned $RESULT, aborting..."
-            exit 1
-          fi
+        if [[ ${{ steps.get-version-current.outputs.version }} == "$VERSION" ]]; then
+          echo "::notice::Current version ($VERSION) == latest version, skipping PR creation..."
+          echo "result=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if $(${{ inputs.should-create-pr }} "$VERSION"); then
+          RESULT="0"
         else
-          echo "result=no" >> $GITHUB_OUTPUT
+          RESULT=$?
+        fi
+
+        if [[ "$RESULT" -eq "0" ]]; then
+          echo "result=true" >> $GITHUB_OUTPUT
+        elif [[ "$RESULT" -eq "1" ]]; then
+          echo "::notice::User provided ${{ inputs.should-create-pr }} returned 1, skipping PR creation..."
+          echo "result=false" >> $GITHUB_OUTPUT
+        else
+          echo "::error::User provided ${{ inputs.should-create-pr }} returned $RESULT, aborting..."
+          exit 1
         fi
 
     ############################################################################
@@ -142,7 +144,7 @@ runs:
     # [2]: "base" is GitHub lingo for "the branch without your changes".
     ############################################################################
     - name: Create PR Metadata
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       shell: bash
       # Write a JSON object to the temporary file `metadata/metadata.json` that
       # contains information about what this job is going to do.  Populate four
@@ -259,7 +261,7 @@ runs:
     #
     # [3]: https://pandoc.org/
     - name: Generate PR Title
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       uses: docker://pandoc/core
       with:
         args: >-
@@ -270,7 +272,7 @@ runs:
           -o metadata/pr-title.md
           /dev/null
     - name: Generate PR Body
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       uses: docker://pandoc/core
       with:
         args: >-
@@ -281,7 +283,7 @@ runs:
           -o metadata/pr-body.md
           /dev/null
     - name: Generate Commit Message
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       uses: docker://pandoc/core
       with:
         args: >-
@@ -294,7 +296,7 @@ runs:
     # Print the populated pandoc templates to the GitHub Actions step summary.
     # (These will print on the "Summary" of a run of this Action.)
     - name: Show Metadata
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       shell: bash
       run: |
         echo "# PR Title" >> $GITHUB_STEP_SUMMARY
@@ -308,7 +310,7 @@ runs:
     # Using the information in the JSON Metadata, cherry-pick all commits from
     # the staging branch.
     - name: Cherry Pick Staging Branch Commits
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       shell: bash
       run: |
         cd downstream/
@@ -323,7 +325,7 @@ runs:
         done
     # Create unstaged changes that updates the CIRCT version to "latest".
     - name: Update Downstream Project to Latest Upstream Release
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       shell: bash
       run: |
         cd downstream/
@@ -342,7 +344,7 @@ runs:
       #
       # [4]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
     - name: Setup Environment with Metadata
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       id: setup-env
       shell: bash
       run: |
@@ -358,7 +360,7 @@ runs:
     # Commit unstaged changes, create or update the PR, notify reviewers, and
     # add labels.
     - name: Create PR
-      if: steps.open-pr.outputs.result == 'yes'
+      if: steps.open-pr.outputs.result == 'true'
       id: create-pr
       uses: peter-evans/create-pull-request@v5
       with:


### PR DESCRIPTION
This optional input takes a script as an argument that lets the user decide if the PR should be created based on the candidate version of firtool.

Tested a bit here: https://github.com/jackkoenig/chisel/actions/workflows/cd-circt.yml

Showing the 3 possibilities:
* Success (script returns 0)  - https://github.com/jackkoenig/chisel/actions/runs/10257662561 (note the action failed because I don't have the token set up to open a PR)
* Skip (script returns 1) - https://github.com/jackkoenig/chisel/actions/runs/10257753361
* Abort (script returns not 0 nor 1) - https://github.com/jackkoenig/chisel/actions/runs/10257762647